### PR TITLE
Add testing for .Net 8.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore src
     - name: Build

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The .Net 7.0 version has additional support for `required` properties, and can u
 
 To build Ookii.CommandLine, make sure you have the following installed:
 
-- [Microsoft .Net 7.0 SDK](https://dotnet.microsoft.com/download) or later
+- [Microsoft .Net 8.0 SDK](https://dotnet.microsoft.com/download) or later
 - [Microsoft PowerShell 6 or later](https://github.com/PowerShell/PowerShell)
 
 PowerShell is used to generate some source files during the build. Besides installing it normally,
@@ -164,8 +164,9 @@ To build the library, tests and samples, simply use the `dotnet build` command i
 directory. You can run the unit tests using `dotnet test`. The tests should pass on all platforms
 (Windows and Linux have been tested).
 
-The tests are built and run for .Net 7.0, .Net 6.0, and .Net Framework 4.8. Running the .Net
-Framework tests on a non-Windows platform may require the use of [Mono](https://www.mono-project.com/).
+The tests are built and run for .Net 8.0, .Net 7.0, .Net 6.0, and .Net Framework 4.8. Running the
+.Net Framework tests on a non-Windows platform may require the use of
+[Mono](https://www.mono-project.com/).
 
 Ookii.CommandLine uses a strongly-typed resources file, which will not update correctly unless the
 `Resources.resx` file is edited with [Microsoft Visual Studio](https://visualstudio.microsoft.com/).

--- a/src/Ookii.CommandLine.Tests/Ookii.CommandLine.Tests.csproj
+++ b/src/Ookii.CommandLine.Tests/Ookii.CommandLine.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net48</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AssemblyTitle>Ookii.CommandLine Unit Tests</AssemblyTitle>
     <Description>Tests for Ookii.CommandLine.</Description>

--- a/src/Ookii.CommandLine/Ookii.CommandLine.csproj
+++ b/src/Ookii.CommandLine/Ookii.CommandLine.csproj
@@ -62,7 +62,7 @@ library for .Net applications.
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netstandard2.1'" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)'=='netstandard2.0'" />
   </ItemGroup>
 


### PR DESCRIPTION
At this time, I don't believe it's necessary to update Ookii.CommandLine itself to .Net 8, as the .Net 7 version of the library will work in .Net 8 projects. However, the unit tests add a .Net 8.0 target to ensure everything works correctly.